### PR TITLE
Get it to work for local file sources

### DIFF
--- a/webmixer/utils.py
+++ b/webmixer/utils.py
@@ -41,6 +41,11 @@ def generate_filename(link, default_ext=None):
     return "{}{}".format(hash_object.hexdigest(), ext or default_ext)
 
 
+def is_absolute(url):
+    """Return whether URL has a host domain or has a scheme eg. 'file://...'"""
+    return bool(urlparse(url).netloc) or bool(urlparse(url).scheme)
+
+
 def get_absolute_url(url, endpoint=None):
     """
         Returns the absolute url based on the url and endpoint
@@ -49,10 +54,10 @@ def get_absolute_url(url, endpoint=None):
             endpoint (str): link to convert to an absolute url (e.g. /image.png)
     """
     endpoint = endpoint.replace('%20', ' ').strip()
-    if endpoint.startswith(('http', 'file://')):
-        return endpoint
-    elif endpoint.startswith('//'):
+    if endpoint.startswith('//'):
         return 'https:{}'.format(endpoint)
+    elif is_absolute(endpoint):
+        return endpoint
     elif '../' in endpoint:
         jumps = len(list(section for section in endpoint.split('/') if section == '..'))
         url_sections = url.split('/')[:-(jumps + 1)] + endpoint.split('/')[jumps:]

--- a/webmixer/utils.py
+++ b/webmixer/utils.py
@@ -49,7 +49,7 @@ def get_absolute_url(url, endpoint=None):
             endpoint (str): link to convert to an absolute url (e.g. /image.png)
     """
     endpoint = endpoint.replace('%20', ' ').strip()
-    if endpoint.strip().startswith('http'):
+    if endpoint.startswith(('http', 'file://')):
         return endpoint
     elif endpoint.startswith('//'):
         return 'https:{}'.format(endpoint)


### PR DESCRIPTION
In particular, get `get_absolute_url` to recognize `file://path/to/file` as a valid absolute URL that doesn't need to be changed. This allows us to use webmixer on local files, e.g. 

```
guess_scraper('file://path/to/file').download_file('myfile.zip')
```

Tested with the IMSCP library that uses webmixer to package together required files for an HTML app from a locally downloaded IMS content package: https://github.com/learningequality/imscp/pull/3 (which also requires [this webmixer PR](https://github.com/learningequality/webmixer/pull/3))

