### PR TITLE
Small fixes for PresentationScraper generate_slideshow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.11.1
-beautifulsoup4>=4.6.3
+beautifulsoup4<4.9.0,>=4.6.3
 ricecooker>=0.6.31
 le_utils>=0.1.19
 cssutils>=1.0.2

--- a/webmixer/scrapers/pages/presentations.py
+++ b/webmixer/scrapers/pages/presentations.py
@@ -37,6 +37,11 @@ class PresentationScraper(HTMLPageScraper):
         page.body['class'] = ['collapsed']
         page.body['onclick'] = 'closeDropdown()'
 
+        # make sure page has a text encoding
+        meta = self.create_tag('meta')
+        meta.attrs['charset'] = 'utf-8'
+        page.head.append(meta)
+
         # <style>
         style = self.create_tag('style')
         style.string = '#gallery {width: 100vw;}\n'\

--- a/webmixer/scrapers/pages/presentations.py
+++ b/webmixer/scrapers/pages/presentations.py
@@ -88,7 +88,7 @@ class PresentationScraper(HTMLPageScraper):
         # <button id="next-btn">
         nextbutton = self.create_tag('button')
         nextbutton['id'] = 'next-btn'
-        nextbutton.string = '🡒'
+        nextbutton.string = '→'
         nextbutton['style'] = 'float:right; background-color: transparent; border: none; font-size: 17pt; color: white; width:75px; font-size:16pt;'
         nextbutton['onclick'] = 'updateImage(1)'
         nextbutton['title'] = MESSAGES[self.locale]['next']
@@ -106,7 +106,7 @@ class PresentationScraper(HTMLPageScraper):
         # <button id="prev-btn">
         prevbutton = self.create_tag('button')
         prevbutton['id'] = 'prev-btn'
-        prevbutton.string = '🡐'
+        prevbutton.string = '←'
         prevbutton['style'] = 'float:left; background-color: transparent; border: none; font-size: 17pt; color: white; width:75px; font-size:16pt;'
         prevbutton['onclick'] = 'updateImage(-1)'
         prevbutton['title'] = MESSAGES[self.locale]['previous']


### PR DESCRIPTION
Three minor fixes while testing @jayoshih code sample:

```
from webmixer.scrapers.pages.presentations import PresentationScraper
SAMPLE_IMAGES = [
  "https://i.imgflip.com/1s19ek.jpg",
  "https://i.ytimg.com/vi/CSHbSe7iW_E/maxresdefault.jpg",
  "https://i.pinimg.com/236x/e9/a7/0a/e9a70a5e5e6314887b67e9ff8411b5df--funny-penguin-penguin-s.jpg",
  "https://i.ytimg.com/vi/IjewsB1ChPM/hqdefault.jpg",
  "https://cdn.quotesgram.com/img/5/96/2094298081-funny-penguin-duck.jpg",
  "https://amolife.com/image/images/stories/Animals/funny_rabbits_1.jpg",
]
class SlideshowZipScraper(PresentationScraper):
  def process(self):
    images = []
    for img  in SAMPLE_IMAGES:
        images.append(self.write_url(img, directory="slides"))
    return self.generate_slideshow(images)
SlideshowZipScraper('').to_file('sample-presentation.zip', directory="scraped")

```


1. The arrow [unicode characters](https://www.fileformat.info/info/unicode/char/1f852/index.htm) were showing as TOFU on mac, so replaced with a different arrow character.

Before:
<img width="956" alt="Screen Shot 2020-07-09 at 10 21 11 AM" src="https://user-images.githubusercontent.com/163966/87052503-db023480-c1ce-11ea-977f-21ee64efcc30.png">

After:
<img width="976" alt="Screen Shot 2020-07-09 at 10 21 19 AM" src="https://user-images.githubusercontent.com/163966/87052524-dfc6e880-c1ce-11ea-8ccf-243eb7ceb692.png">



2.  When served using `python3 -m http.server` the missing text encoding for the page was showing weird chars:

Before:
<img width="775" alt="Screen Shot 2020-07-09 at 10 19 13 AM" src="https://user-images.githubusercontent.com/163966/87052724-1997ef00-c1cf-11ea-8186-88870e48d71c.png">


After adding meta charset tag:
<img width="600" alt="Screen Shot 2020-07-09 at 10 20 27 AM" src="https://user-images.githubusercontent.com/163966/87052760-26b4de00-c1cf-11ea-9e9f-2f31e5a816a8.png">


3. Some warnings about beatuifulsoup4 version:
<img width="1039" alt="Screen Shot 2020-07-09 at 10 11 16 AM" src="https://user-images.githubusercontent.com/163966/87052818-3e8c6200-c1cf-11ea-8df9-a0bd1d820868.png">

so I pinned to the same version used by ricecooker, pressurecooker, and le-pycaption (the pin is required for a particular format of subtitles .sami, so kind of an edge case but if we want to support all the le-pycaption functionality we have to keep the beatuifulsoup4 pinned to 4.8.* releases)

